### PR TITLE
Display graphs

### DIFF
--- a/dot.lua
+++ b/dot.lua
@@ -1,0 +1,26 @@
+local iterm = require 'iterm.env'
+require 'graph'
+
+-- see `man dot` for all preferences
+local default_attr = {
+   color = 'yellow',
+   style = 'filled',
+   shape = 'box',
+   fontsize = 10,
+}
+
+-- as default rendering is not pretty we set our own graphNodeAttributes
+-- if they are not set already
+-- mutates the graph!
+function iterm.dot(g,fname,attr)
+   attr = attr or default_attr
+   local f = function() return attr end
+   for i,v in ipairs(g.nodes) do
+      if v.data and not v.graphNodeAttributes then v.graphNodeAttributes = f end
+   end
+   fname = fname or os.tmpname()..'.pdf'
+   graph.graphvizFile(g, 'dot', fname)
+   iterm.display(fname)
+end
+
+return iterm

--- a/env.lua
+++ b/env.lua
@@ -1,0 +1,2 @@
+local iterm = {}
+return iterm

--- a/init.lua
+++ b/init.lua
@@ -1,11 +1,10 @@
 -- For explanation see https://iterm2.com/images.html
 -- 2016 Sergey Zagoruyko
 
-local iterm = {}
+local iterm = require 'iterm.env'
 require 'image'
 local base64 = require 'base64'
 local ffi = require 'ffi'
-require 'graph'
 
 local function print_osc()
    if os.getenv'TERM' == 'screen' then
@@ -71,27 +70,5 @@ function iterm.display(img, opts)
 end
 
 iterm.image = iterm.display
-
--- see `man dot` for all preferences
-local default_attr = {
-   color = 'yellow',
-   style = 'filled',
-   shape = 'box',
-   fontsize = 10,
-}
-
--- as default rendering is not pretty we set our own graphNodeAttributes
--- if they are not set already
--- mutates the graph!
-function iterm.dot(g,fname,attr)
-   attr = attr or default_attr
-   local f = function() return attr end
-   for i,v in ipairs(g.nodes) do
-      if v.data and not v.graphNodeAttributes then v.graphNodeAttributes = f end
-   end
-   fname = fname or os.tmpname()..'.pdf'
-   graph.graphvizFile(g, 'dot', fname)
-   display(fname)
-end
 
 return iterm

--- a/iterm-scm-1.rockspec
+++ b/iterm-scm-1.rockspec
@@ -23,5 +23,7 @@ build = {
    type = "builtin",
    modules = {
       ['iterm.init'] = 'init.lua',
+      ['iterm.env'] = 'env.lua',
+      ['iterm.dot'] = 'dot.lua',
    }
 }


### PR DESCRIPTION
This is wicked, displays graphs directly in terminal. Goes well with @fmassa's https://github.com/fmassa/optimize-net, although adds dependency on graph. Simple example:

cc @soumith @Atcold

``` lua
local iterm = require 'iterm'
local models = require 'optnet.models'
local generateGraph = require 'optnet.graphgen'

local modelname = 'googlenet'
local net, input = models[modelname]()

local g = generateGraph(net, input)

iterm.dot(g, paths.tmpname()..'..png')
```

Will show this in terminal:

![googlenet](https://cloud.githubusercontent.com/assets/4953728/13821844/9c63e878-eba3-11e5-8f82-049d6525ddc7.png)

Had to tweak optimize-net graphviz settings
