### PR TITLE
gnuplot extension

### DIFF
--- a/gnuplot.lua
+++ b/gnuplot.lua
@@ -1,0 +1,19 @@
+require 'gnuplot'
+local iterm = require 'iterm'
+
+local itermplot = gnuplot
+
+function itermplot.itermfigure(engine)
+   engine = engine or 'png'
+   itermplot.name = paths.tmpname()..'.'..engine
+   gnuplot[engine..'figure'](itermplot.name)
+end
+
+function itermplot.show()
+   gnuplot.plotflush()
+   gnuplot.close()
+   iterm.display(itermplot.name)
+   itermplot.name = nil
+end
+
+return itermplot

--- a/iterm-scm-1.rockspec
+++ b/iterm-scm-1.rockspec
@@ -25,5 +25,6 @@ build = {
       ['iterm.init'] = 'init.lua',
       ['iterm.env'] = 'env.lua',
       ['iterm.dot'] = 'dot.lua',
+      ['iterm.gnuplot'] = 'gnuplot.lua',
    }
 }


### PR DESCRIPTION
registers in gnuplot 2 additional functions, `itermfigure` and `show`
example:

``` lua
local iterm = require 'iterm'
local plot = require 'iterm.gnuplot'

local engine = 'png'

plot.itermfigure(engine)
plot.plot(torch.randn(16))
plot.show()
print''

plot.itermfigure(engine)
x = torch.linspace(-1,1)
xx = torch.Tensor(x:size(1),x:size(1)):zero():addr(1,x,x)
xx = xx*math.pi*2
gnuplot.splot({torch.sin(xx)},{torch.sin(xx)+2})
plot.show()
```

will show:
![screen shot 2016-03-27 at 22 37 56](https://cloud.githubusercontent.com/assets/4953728/14067867/df841914-f46f-11e5-9f14-ef420756129b.png)

`gnuplot` is still optional
